### PR TITLE
addon configuration and host filtering list.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,17 @@
 {
     "manifest_version": 2,
     "name": "wow-dpi",
-    "version": "1.2",
+    "version": "1.3",
     
     "description": "Wow such DPI much blacklist very 1984",
     
-    "permissions": ["webRequest", "webRequestBlocking", "http://*/*"],
+    "permissions": ["storage", "webRequest", "webRequestBlocking", "*://*/*"],
 
     "background": {
         "scripts": ["wowdpi.js"]
+    },
+
+    "options_ui": {
+        "page": "options.html"
     }
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+
+  <body>
+    <h2>Configuration:</h2>
+    <form>
+        <label>Insert whitespace before host value <input type="checkbox" id="addSpace" ></label><br/><br/>
+	<label>Replace 'Host' key with:<br/><input type="text" id="hostValue" style="width: 100%"></label><br/><br/>
+	Applies to (<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns">match patterns</a> separated by new-line):<br/>
+	<textarea id="filterList" style="width: 100%"></textarea><br/>
+	<br/>
+        <button type="button" id="saveButton" style="float:right">Save</button>
+    </form>
+
+    <script src="options.js"></script>
+  </body>
+
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,30 @@
+/**
+ * Options:
+ * addSpace - boolean, adds whitespace before host name value;
+ * hostValue - string, value to replace original "Host" key;
+ * filterList - array of match patterns https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns
+ */
+
+function onError(err) {
+	console.log("Error: ", err);
+}
+
+function restoreOptions() {
+	browser.storage.local.get(["addSpace", "hostValue", "filterList"]).then(function(val) {
+		document.querySelector("#addSpace").checked = val.addSpace;
+		document.querySelector("#hostValue").value = val.hostValue;
+		document.querySelector("#filterList").value = val.filterList.join("\n");
+	}, onError);
+}
+
+function saveOptions() {
+	browser.storage.local.set({
+		addSpace: document.querySelector("#addSpace").checked,
+		hostValue: document.querySelector("#hostValue").value,
+		filterList: document.querySelector("#filterList").value.split("\n")
+	});
+}
+
+document.addEventListener("DOMContentLoaded", restoreOptions);
+document.querySelector("#saveButton").addEventListener("click", saveOptions);
+

--- a/wowdpi.js
+++ b/wowdpi.js
@@ -1,15 +1,56 @@
-function mangleHost(e) {
-    for (var header of e.requestHeaders) {
-        if (header.name.toLowerCase() == "host") {
-            header.value = ' ' + header.value;
-            // header.name = "HoSt";
-        }
-    }
-    return {requestHeaders: e.requestHeaders};
-}
+browser.storage.local.get(["addSpace", "hostValue", "filterList"]).then(function(newconfig) {
+	// load config or use defaults
+	var config = {
+		addSpace: newconfig.addSpace || false,
+		hostValue: newconfig.hostValue || "HoSt",
+		filterList: newconfig.filterList || ["*://*/*"]
+	};
 
-browser.webRequest.onBeforeSendHeaders.addListener(
-    mangleHost,
-    {urls: ["http://*/*"]},
-    ["blocking", "requestHeaders"]
-);
+	// changes request headers
+	function mangleHost(e) {
+		for (var header of e.requestHeaders) {
+			if(header.name.toLowerCase() == "host") {
+				console.log("Overriding header for: ", header.value);
+				if(config.addSpace)
+					header.value = ' ' + header.value;
+				header.name = config.hostValue;
+				break; // don't check other headers
+			}
+	    	}
+		return {requestHeaders: e.requestHeaders};
+	}
+
+	// update config when changed
+	function storageChanged(changes, area) {
+		if(area !== 'local')
+			return;
+
+		config.addSpace = changes.addSpace.newValue;
+		config.hostValue = changes.hostValue.newValue;
+		config.filterList = changes.filterList.newValue;
+
+		console.log("Config updated:", config);
+
+		// remove old listener if required
+		if(browser.webRequest.onBeforeSendHeaders.hasListener(mangleHost))
+			browser.webRequest.onBeforeSendHeaders.removeListener(mangleHost)
+
+		// listen for headers
+		browser.webRequest.onBeforeSendHeaders.addListener(
+			mangleHost,
+			{urls: config.filterList },
+			["blocking", "requestHeaders"]
+		);
+	}
+
+	// listen to config changes
+	browser.storage.onChanged.addListener(storageChanged);
+
+	// ensure config is saved initially to be used in options.js later (defaults)
+	// also adds listener in storageChanged
+	browser.storage.local.set(config);
+
+	
+}, function(err) {
+	console.log("Error: ", error);
+});


### PR DESCRIPTION
Hello.
I see that you have commented the line of one possible changes for requests to avoid dpi,
so I decided to make this optional to configure one of the methods or both to change the requests.
I also changed addons permissions to *  : // * / * so it will work with https also, but actually user can change this in options now by specifying match filter they like (which applied in js). By the docs it seems that it will not conflict with ftp connections. Anyways it's possible to put default value to: http : // * / * and it will work as original one.
Would be nice to see this extension updated as I have no MDN account and can't sign extension.
Originally the Host->'HoSt' change didn't work with my ISP, so I tried the commented line and it seemed to be working, but currently I end up it sometimes works both ways but it mostly fail if I start connecting without extension first and then enable it and try to reconnect. Or I miss something...
PS this is my first pull request, not much into git, so sorry if I did something wrong. Atleast try how it works for you. I also left some debug output so you'll be able to see when the extension changes the request.