### PR TITLE
changed the default filter to http like old version does

### DIFF
--- a/wowdpi.js
+++ b/wowdpi.js
@@ -3,7 +3,7 @@ browser.storage.local.get(["addSpace", "hostValue", "filterList"]).then(function
 	var config = {
 		addSpace: newconfig.addSpace || false,
 		hostValue: newconfig.hostValue || "HoSt",
-		filterList: newconfig.filterList || ["*://*/*"]
+		filterList: newconfig.filterList || ["http://*/*"]
 	};
 
 	// changes request headers
@@ -33,7 +33,7 @@ browser.storage.local.get(["addSpace", "hostValue", "filterList"]).then(function
 
 		// remove old listener if required
 		if(browser.webRequest.onBeforeSendHeaders.hasListener(mangleHost))
-			browser.webRequest.onBeforeSendHeaders.removeListener(mangleHost)
+			browser.webRequest.onBeforeSendHeaders.removeListener(mangleHost);
 
 		// listen for headers
 		browser.webRequest.onBeforeSendHeaders.addListener(


### PR DESCRIPTION
Changed the default filter back to http, so this won't break default behavior of previous version, users may change it whatever they want (back to * or specific hosts).
Overall about extension: In my case it seems that blocked https hosts are redirected by my ISP and I have no idea how to skip redirection response which comes in first order before the actual one ('passive dpi' according to https://github.com/ValdikSS/GoodbyeDPI).